### PR TITLE
Add i18n parity check between en.json and ar.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "audit:deadcode:main": "knip --no-progress --no-config-hints --include files,dependencies",
     "audit:deadcode:ui": "knip --no-progress --no-config-hints --include files,dependencies --directory ui",
     "audit:deadcode": "npm run audit:deadcode:main && npm run audit:deadcode:ui",
-    "check": "npm run lint && npm run typecheck && npm run test",
+    "check:i18n": "node scripts/check-i18n.js",
+    "check": "npm run lint && npm run typecheck && npm run check:i18n && npm run test",
     "clean:generated": "rm -rf dist .next coverage ui/.next ui/out ui/.vercel ui/public/peaks ui/tsconfig.tsbuildinfo"
   },
   "description": "Automated Quran Recitation Synchronization",

--- a/scripts/check-i18n.js
+++ b/scripts/check-i18n.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const LOCALES_DIR = path.join(ROOT, 'ui', 'messages');
+const REFERENCE = 'en.json';
+const TARGETS = ['ar.json'];
+
+function flatten(value, prefix) {
+  const out = new Set();
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      for (const leaf of flatten(child, path)) {
+        out.add(leaf);
+      }
+    }
+  } else {
+    out.add(prefix);
+  }
+  return out;
+}
+
+function readKeys(file) {
+  const full = path.join(LOCALES_DIR, file);
+  let raw;
+  try {
+    raw = fs.readFileSync(full, 'utf8');
+  } catch (err) {
+    console.error(`Cannot read ${full}: ${err.message}`);
+    process.exit(2);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.error(`Invalid JSON in ${full}: ${err.message}`);
+    process.exit(2);
+  }
+  return flatten(parsed, '');
+}
+
+const reference = readKeys(REFERENCE);
+let failed = false;
+
+for (const target of TARGETS) {
+  const targetKeys = readKeys(target);
+  const missingInTarget = [...reference].filter((k) => !targetKeys.has(k)).sort();
+  const extraInTarget = [...targetKeys].filter((k) => !reference.has(k)).sort();
+
+  if (missingInTarget.length === 0 && extraInTarget.length === 0) {
+    console.log(`${target}: OK (${targetKeys.size} keys match ${REFERENCE})`);
+    continue;
+  }
+
+  failed = true;
+  console.error(`${target}: parity check failed against ${REFERENCE}`);
+  if (missingInTarget.length > 0) {
+    console.error(`  Missing in ${target} (${missingInTarget.length}):`);
+    for (const key of missingInTarget) console.error(`    - ${key}`);
+  }
+  if (extraInTarget.length > 0) {
+    console.error(`  Extra in ${target} (not in ${REFERENCE}) (${extraInTarget.length}):`);
+    for (const key of extraInTarget) console.error(`    - ${key}`);
+  }
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds a Node-based script that fails the build when `ui/messages/en.json` and `ui/messages/ar.json` have any mismatched keys. Wired into `npm run check`, so CI enforces parity on every PR.

## What this does

- `scripts/check-i18n.js` flattens both locale files to dotted key paths (e.g. `qa.title`) and prints a clear diff for missing/extra keys.
- New script: `npm run check:i18n` runs it standalone.
- Updated: `npm run check` now invokes `check:i18n` between `typecheck` and `test`.
- No new dependencies — uses only `node:fs` and `node:path`.

## How to verify

Pass case:

```
$ npm run check:i18n
ar.json: OK (294 keys match en.json)
```

Failure case (remove `qa.title` from `ar.json` and add an extra key):

```
ar.json: parity check failed against en.json
  Missing in ar.json (1):
    - qa.title
  Extra in ar.json (not in en.json) (1):
    - qa.extraOnlyInAr
```

Exit code is `1` on mismatch, `0` on parity.

## Test plan

- [x] `npm run check:i18n` passes on current `main`
- [x] Synthetic mismatch causes exit 1 with readable diff
- [x] `npm run check` integration passes (lint + typecheck + check:i18n + test)
- [x] CI (`.github/workflows/ci.yml`) calls `npm run check`, so no workflow changes needed

Closes #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added i18n validation script integrated into the development build pipeline for locale file verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Itqan-community/munajjam-desktop/pull/13)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->