### PR TITLE
Prune expired export tickets to fix slow memory leak

### DIFF
--- a/src/export-tickets.test.ts
+++ b/src/export-tickets.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EXPORT_TICKET_TTL_MS,
+  consumeExportTicket,
+  getActiveExportTicketCount,
+  issueExportTicket,
+} from "./export-tickets";
+
+describe("export tickets", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    // Expire and drain leftover tickets so module state does not leak between tests:
+    // issueExportTicket prunes expired entries, then consume removes the drain entry itself.
+    vi.advanceTimersByTime(EXPORT_TICKET_TTL_MS * 2);
+    const drainToken = issueExportTicket("/drain");
+    consumeExportTicket(drainToken);
+    vi.useRealTimers();
+  });
+
+  it("issues a token that consume resolves to the original path", () => {
+    const token = issueExportTicket("/tmp/out.json");
+    expect(consumeExportTicket(token)).toBe("/tmp/out.json");
+  });
+
+  it("rejects unknown tokens", () => {
+    expect(() => consumeExportTicket("not-a-real-token")).toThrow(/Invalid export token/);
+  });
+
+  it("rejects expired tokens", () => {
+    const token = issueExportTicket("/tmp/out.json");
+    vi.advanceTimersByTime(EXPORT_TICKET_TTL_MS + 1);
+    expect(() => consumeExportTicket(token)).toThrow(/expired/i);
+  });
+
+  it("removes a token from the map after consume", () => {
+    const token = issueExportTicket("/tmp/out.json");
+    expect(getActiveExportTicketCount()).toBe(1);
+    consumeExportTicket(token);
+    expect(getActiveExportTicketCount()).toBe(0);
+  });
+
+  it("prunes expired tickets when a new ticket is issued", () => {
+    issueExportTicket("/tmp/a");
+    issueExportTicket("/tmp/b");
+    expect(getActiveExportTicketCount()).toBe(2);
+
+    vi.advanceTimersByTime(EXPORT_TICKET_TTL_MS + 1);
+    issueExportTicket("/tmp/c");
+
+    expect(getActiveExportTicketCount()).toBe(1);
+  });
+});

--- a/src/export-tickets.ts
+++ b/src/export-tickets.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "crypto";
+import { IpcHandlerError } from "./errors";
+
+export const EXPORT_TICKET_TTL_MS = 5 * 60 * 1000;
+
+interface ExportTicketEntry {
+  filePath: string;
+  expiresAt: number;
+}
+
+const exportTickets = new Map<string, ExportTicketEntry>();
+
+function pruneExpiredExportTickets(): void {
+  const now = Date.now();
+  for (const [token, entry] of exportTickets) {
+    if (now > entry.expiresAt) {
+      exportTickets.delete(token);
+    }
+  }
+}
+
+export function issueExportTicket(filePath: string): string {
+  pruneExpiredExportTickets();
+  const token = randomUUID();
+  exportTickets.set(token, {
+    filePath,
+    expiresAt: Date.now() + EXPORT_TICKET_TTL_MS,
+  });
+  return token;
+}
+
+export function consumeExportTicket(token: string): string {
+  const entry = exportTickets.get(token);
+  exportTickets.delete(token);
+
+  if (!entry) {
+    throw new IpcHandlerError("EXPORT_TOKEN_INVALID", "Invalid export token");
+  }
+  if (Date.now() > entry.expiresAt) {
+    throw new IpcHandlerError("EXPORT_TOKEN_EXPIRED", "Export token has expired");
+  }
+  return entry.filePath;
+}
+
+export function getActiveExportTicketCount(): number {
+  return exportTickets.size;
+}

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,10 +1,10 @@
 import { ipcMain, BrowserWindow } from "electron";
-import { randomUUID } from "crypto";
 import type { LocalDb } from "./db";
 import type { JobsManager } from "./jobs";
 import type { JobRow } from "./ipc-types";
-import { errorResult, ok, toIpcErrorInfo, IpcHandlerError } from "./errors";
+import { errorResult, ok, toIpcErrorInfo } from "./errors";
 import { approvePath, isPathApproved } from "./approved-paths";
+import { issueExportTicket, consumeExportTicket } from "./export-tickets";
 import { createLogger } from "./logger";
 import { registerDataHandlers } from "./ipc/register-data";
 import { registerDialogHandlers } from "./ipc/register-dialog";
@@ -22,30 +22,6 @@ interface IpcDeps {
 
 const log = createLogger("ipc");
 const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "m4a", "flac"]);
-const EXPORT_TICKET_TTL_MS = 5 * 60 * 1000;
-const exportTickets = new Map<string, { filePath: string; expiresAt: number }>();
-
-function issueExportTicket(filePath: string): string {
-  const token = randomUUID();
-  exportTickets.set(token, {
-    filePath,
-    expiresAt: Date.now() + EXPORT_TICKET_TTL_MS,
-  });
-  return token;
-}
-
-function consumeExportTicket(token: string): string {
-  const entry = exportTickets.get(token);
-  exportTickets.delete(token);
-
-  if (!entry) {
-    throw new IpcHandlerError("EXPORT_TOKEN_INVALID", "Invalid export token");
-  }
-  if (Date.now() > entry.expiresAt) {
-    throw new IpcHandlerError("EXPORT_TOKEN_EXPIRED", "Export token has expired");
-  }
-  return entry.filePath;
-}
 
 function handle<T>(
   channel: string,


### PR DESCRIPTION
## Summary

Fixes the slow memory leak in the export ticket store described in #10. Previously, `src/ipc.ts` held an in-memory `Map` of one-time export tokens that expired after 5 minutes but were never pruned, so failed or abandoned exports accumulated forever in a long-running session.

## What changed

- Extracted ticket logic from `src/ipc.ts` into `src/export-tickets.ts` (similar to how `src/approved-paths.ts` encapsulates its own state).
- `issueExportTicket` now prunes expired entries before issuing the new token. No timers, no shutdown hooks needed.
- Added `getActiveExportTicketCount()` for diagnostics / tests.
- Added `src/export-tickets.test.ts` with vitest coverage:
  - issue + consume round-trip
  - unknown token rejected
  - expired token rejected
  - consumed token removed from map
  - **expired tokens are pruned when a new ticket is issued** (the regression guard)

Public IPC behaviour is unchanged for valid / unexpired tokens.

## Test plan

- [x] `npm run check` passes locally (lint + typecheck + 27 main tests + 12 UI tests)
- [x] New `src/export-tickets.test.ts` covers the pruning step end-to-end
- [x] `src/ipc.ts` continues to delegate `issueExportTicket` / `consumeExportTicket` via the same `RegisterContext` (so `register-dialog.ts` and `register-files.ts` need no changes)

Closes #10
