### PR TITLE
Fix runtime API drift, add Reinstall button, harden macOS installer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munajjam-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munajjam-desktop",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "better-sqlite3": "^11.5.0"
       },
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^8.46.1",
         "@typescript-eslint/parser": "^8.46.1",
         "concurrently": "^8.2.2",
-        "electron": "^32.2.0",
+        "electron": "^32.3.3",
         "electron-builder": "^24.13.3",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "munajjam-desktop",
   "productName": "Munajjam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "dist/main.js",
   "scripts": {
@@ -75,7 +75,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
     "concurrently": "^8.2.2",
-    "electron": "^32.2.0",
+    "electron": "^32.3.3",
     "electron-builder": "^24.13.3",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",

--- a/resources/installers/install-munajjam-macos.sh
+++ b/resources/installers/install-munajjam-macos.sh
@@ -71,9 +71,17 @@ if [[ ! -d "$REPO_DIR/.git" ]]; then
   git clone --depth 1 --branch "$REPO_REF" "$REPO_URL" "$REPO_DIR"
 else
   echo "Updating managed Munajjam repository..."
-  git -C "$REPO_DIR" fetch origin "$REPO_REF" --depth 1
-  git -C "$REPO_DIR" checkout "$REPO_REF"
-  git -C "$REPO_DIR" pull --ff-only origin "$REPO_REF"
+  # Hard-reset to upstream so we recover from any force-push or local drift.
+  # The managed clone is a delivery mechanism, not user-editable work.
+  git -C "$REPO_DIR" fetch --depth 1 origin "$REPO_REF"
+  git -C "$REPO_DIR" reset --hard FETCH_HEAD
+fi
+
+# Drop a stale venv whose linked Python no longer works (e.g. after a Homebrew
+# python@3.12 upgrade that breaks ABI of bundled .so files like pyexpat).
+if [[ -d "$VENV_DIR" ]] && ! "$VENV_PYTHON" -c "import sys, xmlrpc.client" >/dev/null 2>&1; then
+  echo "Existing virtual environment is broken; recreating..."
+  rm -rf "$VENV_DIR"
 fi
 
 if [[ ! -d "$VENV_DIR" ]]; then

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -7,6 +7,7 @@ import { scanAudioFiles } from "./audio-files";
 import { parseJobEvent } from "./job-events";
 import { generatePeaks } from "./peaks";
 import { inspectPythonRuntime, resolveAlignmentEntrypoint } from "./python-runtime";
+import { quranCsvPath } from "./paths";
 import { createLogger } from "./logger";
 import type { AlignmentRow, JobRow, JobConfig } from "./ipc-types";
 
@@ -208,6 +209,7 @@ export class JobsManager {
         ]
           .filter(Boolean)
           .join(path.delimiter),
+        MUNAJJAM_QURAN_CSV: quranCsvPath(),
       },
     });
 

--- a/src/python-check.ts
+++ b/src/python-check.ts
@@ -15,6 +15,7 @@ const log = createLogger("python-check");
 const MUNAJJAM_REPO_URL = "https://github.com/Itqan-community/Munajjam";
 const MUNAJJAM_REPO_REF = "main";
 const PYTHON_VERSION = "3.12";
+let activeInstall: Promise<number> | null = null;
 
 export interface InstallerInvocation {
   command: string;
@@ -130,7 +131,7 @@ function installerEnvironment(): NodeJS.ProcessEnv {
   return { ...env, PYTHONUNBUFFERED: "1", PYTHONIOENCODING: "utf-8" };
 }
 
-export async function installRuntime(): Promise<number> {
+async function runInstallRuntime(): Promise<number> {
   const scriptPath = installerScriptPath();
   const rootPath = managedRuntimeRoot();
   const invocation = resolveInstallerInvocation(process.platform, scriptPath, rootPath);
@@ -190,4 +191,17 @@ export async function installRuntime(): Promise<number> {
       resolve(exitCode);
     });
   });
+}
+
+export async function installRuntime(): Promise<number> {
+  if (activeInstall) {
+    log.info("installRuntime already running; joining existing invocation");
+    return activeInstall;
+  }
+
+  activeInstall = runInstallRuntime().finally(() => {
+    activeInstall = null;
+  });
+
+  return activeInstall;
 }

--- a/ui/components/qa/EmptyStateView.tsx
+++ b/ui/components/qa/EmptyStateView.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useWorkspace } from "@/lib/workspace-context";
+import ReinstallRuntimeButton from "./ReinstallRuntimeButton";
 
 export default function EmptyStateView() {
   const t = useTranslations("qa.workspace");
@@ -30,6 +31,9 @@ export default function EmptyStateView() {
         >
           {t("createFirst")}
         </button>
+        <div className="pt-2">
+          <ReinstallRuntimeButton variant="text" />
+        </div>
       </motion.div>
     </div>
   );

--- a/ui/components/qa/ReinstallRuntimeButton.tsx
+++ b/ui/components/qa/ReinstallRuntimeButton.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { isDesktop, getElectronBridge } from "@/lib/electron";
+import { useEnv } from "@/lib/env-context";
+import type { EnvInstallProgress } from "@/types/munajjam";
+
+type Variant = "text" | "icon";
+type Phase = "idle" | "confirming" | "installing" | "done" | "failed";
+
+interface Props {
+  variant?: Variant;
+}
+
+export default function ReinstallRuntimeButton({ variant = "text" }: Props) {
+  const t = useTranslations("qa.setup");
+  const { recheck } = useEnv();
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [output, setOutput] = useState<string[]>([]);
+  const outputRef = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [output]);
+
+  if (!isDesktop()) return null;
+
+  const reset = () => {
+    setPhase("idle");
+    setOutput([]);
+  };
+
+  const runInstall = async () => {
+    setPhase("installing");
+    setOutput([]);
+    const bridge = getElectronBridge();
+
+    const unsubscribe = bridge.env.subscribe((progress: EnvInstallProgress) => {
+      if (progress.type === "stdout" || progress.type === "stderr") {
+        setOutput((prev) => [...prev, progress.data]);
+        return;
+      }
+      if (progress.type === "exit") {
+        unsubscribe();
+        setPhase(progress.exitCode === 0 ? "done" : "failed");
+        if (progress.exitCode === 0) {
+          recheck();
+        }
+      }
+    });
+
+    try {
+      await bridge.env.installRuntime();
+    } catch {
+      unsubscribe();
+      setPhase("failed");
+    }
+  };
+
+  const trigger =
+    variant === "icon" ? (
+      <button
+        type="button"
+        onClick={() => setPhase("confirming")}
+        className="flex items-center gap-1.5 px-2 py-1 hover:bg-white/10 transition-colors text-white/60 app-no-drag rounded-lg shrink-0"
+        aria-label={t("reinstallTooltip")}
+        title={t("reinstallTooltip")}
+      >
+        <RefreshCw className="w-3.5 h-3.5" />
+      </button>
+    ) : (
+      <button
+        type="button"
+        onClick={() => setPhase("confirming")}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-white/50 hover:text-white/80 hover:bg-white/[0.06] transition-colors rounded-lg app-no-drag"
+      >
+        <RefreshCw className="w-3.5 h-3.5" />
+        {t("reinstallButton")}
+      </button>
+    );
+
+  return (
+    <>
+      {trigger}
+      {phase !== "idle" && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm app-no-drag"
+          role="dialog"
+          aria-modal="true"
+          onClick={(event) => {
+            if (event.target === event.currentTarget && phase !== "installing") {
+              reset();
+            }
+          }}
+        >
+          <div className="bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl w-full max-w-lg mx-4 p-6 space-y-4">
+            {phase === "confirming" && (
+              <>
+                <h3 className="text-base font-semibold text-white">
+                  {t("reinstallConfirmTitle")}
+                </h3>
+                <p className="text-sm text-white/60 leading-relaxed">
+                  {t("reinstallConfirmDesc")}
+                </p>
+                <div className="flex justify-end gap-2 pt-2">
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="px-4 py-2 text-sm text-white/70 hover:bg-white/10 rounded-lg transition-colors"
+                  >
+                    {t("cancel")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={runInstall}
+                    className="px-4 py-2 text-sm bg-white text-black font-semibold rounded-lg hover:bg-white/90 transition-colors"
+                  >
+                    {t("reinstallConfirm")}
+                  </button>
+                </div>
+              </>
+            )}
+
+            {(phase === "installing" || phase === "done" || phase === "failed") && (
+              <>
+                <h3 className="text-base font-semibold text-white">
+                  {phase === "installing"
+                    ? t("installing")
+                    : phase === "done"
+                      ? t("installSuccess")
+                      : t("installFailed")}
+                </h3>
+                <pre
+                  ref={outputRef}
+                  className="bg-black/40 border border-white/10 rounded-lg p-3 text-[11px] font-mono text-white/70 max-h-72 overflow-auto whitespace-pre-wrap break-all"
+                >
+                  {output.join("")}
+                </pre>
+                <div className="flex justify-end pt-1">
+                  <button
+                    type="button"
+                    onClick={reset}
+                    disabled={phase === "installing"}
+                    className="px-4 py-2 text-sm bg-white text-black font-semibold rounded-lg hover:bg-white/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {t("reinstallClose")}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/ui/components/qa/TitleBar.tsx
+++ b/ui/components/qa/TitleBar.tsx
@@ -7,6 +7,7 @@ import { useWorkspace } from "@/lib/workspace-context";
 import { useReciters } from "@/lib/reciters-context";
 import { allSurahs } from "@/lib/surah-metadata";
 import { getElectronBridge } from "@/lib/electron";
+import ReinstallRuntimeButton from "./ReinstallRuntimeButton";
 
 interface TitleBarProps {
   locale: string;
@@ -139,6 +140,8 @@ export default function TitleBar({ locale }: TitleBarProps) {
             <Download className={`w-3.5 h-3.5 ${exporting ? "animate-pulse" : ""}`} />
           </button>
         )}
+
+      <ReinstallRuntimeButton variant="icon" />
     </div>
   );
 }

--- a/ui/messages/ar.json
+++ b/ui/messages/ar.json
@@ -243,7 +243,15 @@
       "munajjamFound": "تم العثور على munajjam",
       "munajjamNotFound": "لم يتم العثور على munajjam",
       "installSuccess": "اكتمل تثبيت البيئة بنجاح",
-      "installFailed": "فشل تثبيت البيئة"
+      "installFailed": "فشل تثبيت البيئة",
+      "reinstallButton": "إعادة تثبيت البيئة",
+      "reinstallShort": "إعادة التثبيت",
+      "reinstallTooltip": "إعادة تثبيت بيئة التشغيل المُدارة",
+      "reinstallConfirmTitle": "إعادة تثبيت بيئة التشغيل المُدارة؟",
+      "reinstallConfirmDesc": "ستتم إعادة تنزيل Munajjam وإعادة تثبيت بيئة Python. قد يستغرق ذلك عدة دقائق ويستخدم بيانات الإنترنت. شغّل هذا بعد تحديث Munajjam، أو عند حدوث خلل في بيئة التشغيل.",
+      "reinstallConfirm": "إعادة التثبيت",
+      "reinstallClose": "إغلاق",
+      "cancel": "إلغاء"
     },
     "workspace": {
       "title": "مساحات العمل",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -243,7 +243,15 @@
       "munajjamFound": "munajjam found",
       "munajjamNotFound": "munajjam not found",
       "installSuccess": "Runtime installation completed successfully",
-      "installFailed": "Runtime installation failed"
+      "installFailed": "Runtime installation failed",
+      "reinstallButton": "Reinstall runtime",
+      "reinstallShort": "Reinstall",
+      "reinstallTooltip": "Reinstall the managed runtime",
+      "reinstallConfirmTitle": "Reinstall the managed runtime?",
+      "reinstallConfirmDesc": "This re-downloads Munajjam and reinstalls the Python environment. It can take several minutes and uses network bandwidth. Run this after updating Munajjam, or if the runtime is misbehaving.",
+      "reinstallConfirm": "Reinstall",
+      "reinstallClose": "Close",
+      "cancel": "Cancel"
     },
     "workspace": {
       "title": "Workspaces",


### PR DESCRIPTION
## Summary

Unblock installed users whose managed Python runtime is on a now-incompatible snapshot of `Itqan-community/Munajjam`, and prevent the same failure mode from recurring.

- **CSV path indirection** — desktop now passes `MUNAJJAM_QURAN_CSV` to the alignment subprocess. The Python side reads that override (separate PR in the Munajjam repo) instead of relying on package data shipping correctly. Future packaging slip-ups no longer break the desktop.
- **Reinstall runtime button** — new `ReinstallRuntimeButton` surfaced in both `TitleBar` and `EmptyStateView`. Users with a stale managed clone can force a fresh sync from upstream main without waiting for the env-check to fail.
- **macOS installer hardening**:
  - Replaced `git pull --ff-only` with `fetch + reset --hard FETCH_HEAD`, so the managed clone recovers from upstream force-pushes instead of dying with "fatal: Not possible to fast-forward".
  - Added a venv health check that drops and recreates the venv when its Python is no longer functional (e.g. after a Homebrew `python@3.12` ABI bump that breaks bundled `.so` files).
- **Electron** bumped 32.2.0 → 32.3.3.
- **App version** bumped to 0.1.2.

Pairs with [Itqan-community/Munajjam#PR-TBD] in the Python repo (adds the `MUNAJJAM_QURAN_CSV` env override on the Python side).

## Test plan

- [ ] Tag `v0.1.2` after merge to trigger `build.yml` and produce release artifacts.
- [ ] On the affected Windows user's machine: update Munajjam, click the new **Reinstall runtime** button in the title bar, confirm, and watch the streamed install complete; then start a job and verify it succeeds.
- [ ] Smoke-test on a Mac with an existing managed clone: confirm the divergent-history case no longer breaks the installer.
- [ ] Smoke-test on a Mac whose Homebrew Python has just been upgraded: confirm the venv health check recreates the venv automatically.
- [ ] RTL: spot-check the new Arabic strings (`qa.setup.reinstall*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to reinstall the runtime environment directly from the application interface with progress monitoring and confirmation dialogs.
  * Enhanced macOS installer with improved repository management and virtual environment validation.

* **Chores**
  * Updated package version to 0.1.2
  * Updated Electron dependency to latest compatible version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Itqan-community/munajjam-desktop/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->